### PR TITLE
Create getter and setter methods for fidoutilsConfig object

### DIFF
--- a/fidoutils.js
+++ b/fidoutils.js
@@ -276,6 +276,18 @@ function canAuthenticateWithCredId(options) {
 	return canAuthenticate;
 }
 
+function getFidoUtilsConfigfromNodeClient() {
+	console.log("get method", fidoutilsConfig);
+	return fidoutilsConfig;
+}
+
+function setFidoUtilsConfig(newObj) {
+	fidoutilsConfig = newObj;
+	// newObj["origin"] = window.location.origin;
+	console.log("new fidoutilsConfig using setter method", newObj);
+	return newObj;
+}
+
 /*
  * Acting as the client+authenticator, prepare a FIDO2 server ServerPublicKeyCredential from a CredentialCreationOptions
  * See example at: https://fidoalliance.org/specs/fido-v2.0-rd-20180702/fido-server-v2.0-rd-20180702.html#example-authenticator-attestation-response
@@ -848,7 +860,7 @@ module.exports = {
 	processCredentialRequestOptions: processCredentialRequestOptions,
 	bytesFromArray: bytesFromArray,
 	base64toBA: base64toBA,
-	base64utobase64: base64utobase64, 
-	certToPEM: certToPEM, 
-	canAuthenticateWithCredId: canAuthenticateWithCredId
+	base64utobase64: base64utobase64,
+	certToPEM: certToPEM,
+	canAuthenticateWithCredId: canAuthenticateWithCredId, getFidoUtilsConfigfromNodeClient: getFidoUtilsConfigfromNodeClient, setFidoUtilsConfig: setFidoUtilsConfig
 };

--- a/fidoutils.js
+++ b/fidoutils.js
@@ -276,7 +276,7 @@ function canAuthenticateWithCredId(options) {
 	return canAuthenticate;
 }
 
-function getFidoUtilsConfigfromNodeClient() {
+function getFidoUtilsConfig() {
 	return fidoutilsConfig;
 }
 
@@ -860,6 +860,6 @@ module.exports = {
 	base64utobase64: base64utobase64,
 	certToPEM: certToPEM,
 	canAuthenticateWithCredId: canAuthenticateWithCredId,
-	getFidoUtilsConfigfromNodeClient: getFidoUtilsConfigfromNodeClient,
+	getFidoUtilsConfig: getFidoUtilsConfig,
 	setFidoUtilsConfig: setFidoUtilsConfig
 };

--- a/fidoutils.js
+++ b/fidoutils.js
@@ -277,14 +277,11 @@ function canAuthenticateWithCredId(options) {
 }
 
 function getFidoUtilsConfigfromNodeClient() {
-	console.log("get method", fidoutilsConfig);
 	return fidoutilsConfig;
 }
 
 function setFidoUtilsConfig(newObj) {
 	fidoutilsConfig = newObj;
-	// newObj["origin"] = window.location.origin;
-	console.log("new fidoutilsConfig using setter method", newObj);
 	return newObj;
 }
 
@@ -862,5 +859,7 @@ module.exports = {
 	base64toBA: base64toBA,
 	base64utobase64: base64utobase64,
 	certToPEM: certToPEM,
-	canAuthenticateWithCredId: canAuthenticateWithCredId, getFidoUtilsConfigfromNodeClient: getFidoUtilsConfigfromNodeClient, setFidoUtilsConfig: setFidoUtilsConfig
+	canAuthenticateWithCredId: canAuthenticateWithCredId,
+	getFidoUtilsConfigfromNodeClient: getFidoUtilsConfigfromNodeClient,
+	setFidoUtilsConfig: setFidoUtilsConfig
 };


### PR DESCRIPTION
This is required in order for me to replace the fidoutilsConfig environment variable with the object produced in my extension background service worker which utilises your node.js script for generating the certificate and keys.